### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,12 +3,7 @@
   "version": "0.6.1",
   "description": "The Bower config reader and writer.",
   "author": "Twitter",
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "https://github.com/bower/config/blob/master/LICENSE"
-    }
-  ],
+  "license": "MIT",
   "repository": "bower/config",
   "main": "lib/Config",
   "homepage": "http://bower.io",


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/