### PR TITLE
Added lib/util/proxy.js which sets proxy variables when config is nor…

### DIFF
--- a/lib/Config.js
+++ b/lib/Config.js
@@ -69,7 +69,7 @@ Config.normalise = function (rawConfig) {
     config.registry.publish = config.registry.publish.replace(/\/+$/, '');
     config.tmp = path.resolve(config.tmp);
 
-    // Set proxy environment variables to what this._config says
+    // Set proxy environment variables to what config says
     proxy.set(config);
 
     return config;

--- a/lib/Config.js
+++ b/lib/Config.js
@@ -3,6 +3,7 @@ var object = require('mout/object');
 var rc = require('./util/rc');
 var defaults = require('./util/defaults');
 var expand = require('./util/expand');
+var proxy = require('./util/proxy');
 var path = require('path');
 
 function Config(cwd) {
@@ -67,6 +68,9 @@ Config.normalise = function (rawConfig) {
     config.registry.register = config.registry.register.replace(/\/+$/, '');
     config.registry.publish = config.registry.publish.replace(/\/+$/, '');
     config.tmp = path.resolve(config.tmp);
+
+    // Set proxy environment variables to what this._config says
+    proxy.set(config);
 
     return config;
 };

--- a/lib/Config.js
+++ b/lib/Config.js
@@ -3,18 +3,25 @@ var object = require('mout/object');
 var rc = require('./util/rc');
 var defaults = require('./util/defaults');
 var expand = require('./util/expand');
-var proxy = require('./util/proxy');
+var EnvProxy = require('./util/proxy');
 var path = require('path');
 
 function Config(cwd) {
     this._cwd = cwd || process.cwd();
+    this._proxy = new EnvProxy();
     this._config = {};
 }
 
 Config.prototype.load = function () {
     this._config = rc('bower', defaults, this._cwd);
+    this._proxy.set(this._config);
     return this;
 };
+
+Config.prototype.restore = function () {
+  this._proxy.reset();
+};
+
 /* jshint ignore:start */
 Config.prototype.get = function (key) {
     // TODO
@@ -68,9 +75,6 @@ Config.normalise = function (rawConfig) {
     config.registry.register = config.registry.register.replace(/\/+$/, '');
     config.registry.publish = config.registry.publish.replace(/\/+$/, '');
     config.tmp = path.resolve(config.tmp);
-
-    // Set proxy environment variables to what config says
-    proxy.set(config);
 
     return config;
 };

--- a/lib/util/proxy.js
+++ b/lib/util/proxy.js
@@ -1,39 +1,18 @@
-var EnvProxy = function() {
-  this.restoreFrom = {};
-  return this;
-};
-
-EnvProxy.prototype.set = function (config) {
-  // Override environment defaults if proxy config options are set
-  // This will make requests.js follow the proxies in config
-  if (Object.prototype.hasOwnProperty.call(config, 'no_proxy')) {
-    this.restoreFrom.NO_PROXY = process.env.NO_PROXY;
-    process.env.NO_PROXY = config.noProxy;
-    delete process.env.no_proxy; // jshint ignore:line
-  }
-  if (Object.prototype.hasOwnProperty.call(config, 'proxy')) {
-    this.restoreFrom.HTTP_PROXY = process.env.HTTP_PROXY;
-    process.env.HTTP_PROXY = config.proxy;
-    delete process.env.http_proxy; // jshint ignore:line
-  }
-  if (Object.prototype.hasOwnProperty.call(config, 'httpsProxy')) {
-    this.restoreFrom.HTTPS_PROXY = process.env.HTTPS_PROXY;
-    process.env.HTTPS_PROXY = config.httpsProxy;
-    delete process.env.https_proxy; // jshint ignore:line
+module.exports = {
+  set: function (config) {
+    // Override environment defaults if proxy config options are set
+    // This will make requests.js follow the proxies in config
+    if (Object.prototype.hasOwnProperty.call(config, 'no_proxy')) {
+      process.env.NO_PROXY = config.noProxy;
+      delete process.env.no_proxy; // jshint ignore:line
+    }
+    if (Object.prototype.hasOwnProperty.call(config, 'proxy')) {
+      process.env.HTTP_PROXY = config.proxy;
+      delete process.env.http_proxy; // jshint ignore:line
+    }
+    if (Object.prototype.hasOwnProperty.call(config, 'httpsProxy')) {
+      process.env.HTTPS_PROXY = config.httpsProxy;
+      delete process.env.https_proxy; // jshint ignore:line
+    }
   }
 };
-
-EnvProxy.prototype.restore = function () {
-  // Reset upercase proxy variables
-  if (Object.prototype.hasOwnProperty.call(this.restoreFrom, 'NO_PROXY')) {
-    process.env.NO_PROXY = this.restoreFrom.NO_PROXY;
-  }
-  if (Object.prototype.hasOwnProperty.call(this.restoreFrom, 'HTTP_PROXY')) {
-    process.env.HTTP_PROXY = this.restoreFrom.HTTP_PROXY;
-  }
-  if (Object.prototype.hasOwnProperty.call(this.restoreFrom, 'HTTPS_PROXY')) {
-    process.env.HTTPS_PROXY = this.restoreFrom.HTTPS_PROXY;
-  }
-};
-
-module.exports = new EnvProxy();

--- a/lib/util/proxy.js
+++ b/lib/util/proxy.js
@@ -1,0 +1,39 @@
+var Proxy = function() {
+  this.restoreFrom = {};
+  return this;
+}
+
+Proxy.prototype.set = function (config) {
+  // Override environment defaults if proxy config options are set
+  // This will make requests.js follow the proxies in config
+  if (Object.prototype.hasOwnProperty.call(config, 'no_proxy')) {
+    this.restoreFrom.NO_PROXY = process.env.NO_PROXY;
+    process.env.NO_PROXY = config.no_proxy;
+    delete process.env.no_proxy;
+  }
+  if (Object.prototype.hasOwnProperty.call(config, 'proxy')) {
+    this.restoreFrom.HTTP_PROXY = process.env.HTTP_PROXY;
+    process.env.HTTP_PROXY = config.proxy;
+    delete process.env.http_proxy;
+  }
+  if (Object.prototype.hasOwnProperty.call(config, 'httpsProxy')) {
+    this.restoreFrom.HTTPS_PROXY = process.env.HTTPS_PROXY;
+    process.env.HTTPS_PROXY = config.httpsProxy;
+    delete process.env.https_proxy;
+  }
+};
+
+Proxy.prototype.restore = function () {
+  // Reset upercase proxy variables
+  if (Object.prototype.hasOwnProperty.call(config, 'no_proxy')) {
+    process.env.NO_PROXY = this.restoreFrom.NO_PROXY;
+  }
+  if (Object.prototype.hasOwnProperty.call(config, 'proxy')) {
+    process.env.HTTP_PROXY = this.restoreFrom.HTTP_PROXY;
+  }
+  if (Object.prototype.hasOwnProperty.call(config, 'httpsProxy')) {
+    process.env.HTTPS_PROXY = this.restoreFrom.HTTPS_PROXY;
+  }
+};
+
+module.exports = new Proxy();

--- a/lib/util/proxy.js
+++ b/lib/util/proxy.js
@@ -1,18 +1,42 @@
-module.exports = {
-  set: function (config) {
-    // Override environment defaults if proxy config options are set
-    // This will make requests.js follow the proxies in config
-    if (Object.prototype.hasOwnProperty.call(config, 'no_proxy')) {
-      process.env.NO_PROXY = config.noProxy;
-      delete process.env.no_proxy; // jshint ignore:line
-    }
-    if (Object.prototype.hasOwnProperty.call(config, 'proxy')) {
-      process.env.HTTP_PROXY = config.proxy;
-      delete process.env.http_proxy; // jshint ignore:line
-    }
-    if (Object.prototype.hasOwnProperty.call(config, 'httpsProxy')) {
-      process.env.HTTPS_PROXY = config.httpsProxy;
-      delete process.env.https_proxy; // jshint ignore:line
-    }
+// EnvProxy uses the proxy vaiables passed to it in set and sets the
+// process.env uppercase proxy variables to them with the ability
+// to restore the original values later
+var EnvProxy = function() {
+  this.restoreFrom = {};
+  return this;
+};
+
+EnvProxy.prototype.set = function (config) {
+  // Override environment defaults if proxy config options are set
+  // This will make requests.js follow the proxies in config
+  if (Object.prototype.hasOwnProperty.call(config, 'no_proxy')) {
+    this.restoreFrom.NO_PROXY = process.env.NO_PROXY;
+    process.env.NO_PROXY = config.noProxy;
+    delete process.env.no_proxy; // jshint ignore:line
+  }
+  if (Object.prototype.hasOwnProperty.call(config, 'proxy')) {
+    this.restoreFrom.HTTP_PROXY = process.env.HTTP_PROXY;
+    process.env.HTTP_PROXY = config.proxy;
+    delete process.env.http_proxy; // jshint ignore:line
+  }
+  if (Object.prototype.hasOwnProperty.call(config, 'https-proxy')) {
+    this.restoreFrom.HTTPS_PROXY = process.env.HTTPS_PROXY;
+    process.env.HTTPS_PROXY = config['https-proxy'];
+    delete process.env.https_proxy; // jshint ignore:line
   }
 };
+
+EnvProxy.prototype.restore = function () {
+  // Reset upercase proxy variables
+  if (Object.prototype.hasOwnProperty.call(this.restoreFrom, 'NO_PROXY')) {
+    process.env.NO_PROXY = this.restoreFrom.NO_PROXY;
+  }
+  if (Object.prototype.hasOwnProperty.call(this.restoreFrom, 'HTTP_PROXY')) {
+    process.env.HTTP_PROXY = this.restoreFrom.HTTP_PROXY;
+  }
+  if (Object.prototype.hasOwnProperty.call(this.restoreFrom, 'HTTPS_PROXY')) {
+    process.env.HTTPS_PROXY = this.restoreFrom.HTTPS_PROXY;
+  }
+};
+
+module.exports = EnvProxy;

--- a/lib/util/proxy.js
+++ b/lib/util/proxy.js
@@ -1,39 +1,39 @@
-var Proxy = function() {
+var EnvProxy = function() {
   this.restoreFrom = {};
   return this;
-}
+};
 
-Proxy.prototype.set = function (config) {
+EnvProxy.prototype.set = function (config) {
   // Override environment defaults if proxy config options are set
   // This will make requests.js follow the proxies in config
   if (Object.prototype.hasOwnProperty.call(config, 'no_proxy')) {
     this.restoreFrom.NO_PROXY = process.env.NO_PROXY;
-    process.env.NO_PROXY = config.no_proxy;
-    delete process.env.no_proxy;
+    process.env.NO_PROXY = config.noProxy;
+    delete process.env.no_proxy; // jshint ignore:line
   }
   if (Object.prototype.hasOwnProperty.call(config, 'proxy')) {
     this.restoreFrom.HTTP_PROXY = process.env.HTTP_PROXY;
     process.env.HTTP_PROXY = config.proxy;
-    delete process.env.http_proxy;
+    delete process.env.http_proxy; // jshint ignore:line
   }
   if (Object.prototype.hasOwnProperty.call(config, 'httpsProxy')) {
     this.restoreFrom.HTTPS_PROXY = process.env.HTTPS_PROXY;
     process.env.HTTPS_PROXY = config.httpsProxy;
-    delete process.env.https_proxy;
+    delete process.env.https_proxy; // jshint ignore:line
   }
 };
 
-Proxy.prototype.restore = function () {
+EnvProxy.prototype.restore = function () {
   // Reset upercase proxy variables
-  if (Object.prototype.hasOwnProperty.call(config, 'no_proxy')) {
+  if (Object.prototype.hasOwnProperty.call(this.restoreFrom, 'NO_PROXY')) {
     process.env.NO_PROXY = this.restoreFrom.NO_PROXY;
   }
-  if (Object.prototype.hasOwnProperty.call(config, 'proxy')) {
+  if (Object.prototype.hasOwnProperty.call(this.restoreFrom, 'HTTP_PROXY')) {
     process.env.HTTP_PROXY = this.restoreFrom.HTTP_PROXY;
   }
-  if (Object.prototype.hasOwnProperty.call(config, 'httpsProxy')) {
+  if (Object.prototype.hasOwnProperty.call(this.restoreFrom, 'HTTPS_PROXY')) {
     process.env.HTTPS_PROXY = this.restoreFrom.HTTPS_PROXY;
   }
 };
 
-module.exports = new Proxy();
+module.exports = new EnvProxy();


### PR DESCRIPTION
Added lib/util/proxy.js which sets process.env.proxy variables when config is normalised

https://github.com/bower/registry-client/pull/22#issuecomment-139344359

@sheerun This way the proxy env variables are set from the config module which I think makes the most sense.

Signed-off-by: John Andersen <johnandersenpdx@gmail.com>