### PR TITLE
Use a pattern match to pass array via process.env

### DIFF
--- a/lib/util/rc.js
+++ b/lib/util/rc.js
@@ -107,7 +107,20 @@ function env(prefix) {
                            .substr(prefixLength)
                            .replace(/__/g, '.')   // __ is used for nesting
                            .replace(/_/g, '-');   // _ is used as a - separator
-            object.set(obj, parsedKey, value);
+
+            //use a convention patern to accept array from process.env
+            //e.g. export bower_registry__search='["http://abc.com","http://def.com"]'
+            var match = /\[([^\]]*)\]/g.exec(value);
+            var targetValue;
+            if (!match || match.length === 0) {
+                targetValue = value;
+            } else {
+                targetValue = match[1].split(',')
+                    .map(function(m) {
+                        return m.trim().slice(1, m.length - 1);
+                    });
+            }
+            object.set(obj, parsedKey, targetValue);
         }
     });
 


### PR DESCRIPTION
This is an proposal to solve request like https://github.com/bower/bower/issues/1804. 

The solution is to use a regex pattern to define a string as an array representation.   With this convention, we are able to  do

```
export  bower_registry__search="[[http://bower.company.com(,)http://bower.herokuapp.com]]";  ./bower install  components-on-private-bower
```