### PR TITLE
Load custom CA file for "default"

### DIFF
--- a/lib/Config.js
+++ b/lib/Config.js
@@ -54,16 +54,18 @@ function loadCAs(caConfig) {
     // If a ca file path has been specified, expand that here to the file's
     // contents. As a user can specify these individually, we must load them
     // one by one.
-    if (caConfig.search) {
-        caConfig.search = caConfig.search.map(function(s) {
-            return readCertFile(s);
-        });
-    }
-    ['register', 'publish'].forEach(function(p) {
-        if (caConfig[p]) {
-            caConfig[p] = readCertFile(caConfig[p]);
+    for (var p in caConfig) {
+        if (caConfig.hasOwnProperty(p)) {
+            var prop = caConfig[p];
+            if (Array.isArray(prop)) {
+                caConfig[p] = prop.map(function(s) {
+                    return readCertFile(s);
+                });
+            } else if (prop) {
+                caConfig[p] = readCertFile(prop);
+            }
         }
-    });
+    }
 }
 
 Config.prototype.toObject = function () {

--- a/test/test.js
+++ b/test/test.js
@@ -120,7 +120,7 @@ describe('NPM Config on package.json', function () {
             var config = require('../lib/Config')
                 .read(path.resolve('test/assets/custom-ca'));
 
-            ['register', 'publish'].forEach(function (p) {
+            ['register', 'publish', 'default'].forEach(function (p) {
                 assertCAContents(config.ca[p], 'config.ca.' + p);
             });
 
@@ -136,7 +136,7 @@ describe('NPM Config on package.json', function () {
             var config = require('../lib/Config')
                 .read(path.resolve('test/assets/custom-ca-embed'));
 
-            ['register', 'publish'].forEach(function (p) {
+            ['register', 'publish', 'default'].forEach(function (p) {
                 assertCAContents(config.ca[p], 'config.ca.' + p);
             });
 


### PR DESCRIPTION
An extra CA property `default` had been added, but the CA file was not loaded for that. In order to prevent similar things happening later on, I thought I'd make the mechanism a bit more generic.

Without this, the `default` property keeps the path to the CA file, while all others have the CA file's contents.

Together with bower/bower#1972, downloading with `strict-ssl` using a custom CA now works again.