### PR TITLE
Added newer Node versions to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: false
 language: node_js
 node_js:
-  - 'iojs'
+  - '5'
+  - '4'
   - '0.12'
   - '0.10'


### PR DESCRIPTION
ADDED/UPDATED:
- Updated Travis file to not test against `iojs` anymore
- Added versions 4 and 5 of Node to test against on Travis