### PR TITLE
fixed type error

### DIFF
--- a/lib/util/paths.js
+++ b/lib/util/paths.js
@@ -18,7 +18,7 @@ var paths = {
 
 // Guess some needed properties based on the user OS
 var user = (osenv.user() || generateFakeUser()).replace(/\\/g, '-');
-var tmp = path.join(os.tmpdir ? os.tmpdir() : os.tmpDir(), user);
+var tmp = path.join(os.tmpdir ? os.tmpdir() : os.tmpdir(), user);
 var home = osenv.home();
 var base;
 


### PR DESCRIPTION
There was a type error in following line https://github.com/bower/config/blob/master/lib/util/paths.js#L21 it should be `os.tmpdir` instead of `os.tmpDir`

````
var tmp = path.join(os.tmpdir ? os.tmpdir() : os.tmpDir(), user);
````

Bug: #35 