### PR TITLE
add default values for save and save-exact

### DIFF
--- a/lib/util/defaults.js
+++ b/lib/util/defaults.js
@@ -33,6 +33,8 @@ var defaults = {
     'user-agent': userAgent,
     'color': true,
     'interactive': null,
+    'save': false,
+    'save-exact': false,
     'storage': {
         packages: path.join(paths.cache, 'packages'),
         links: path.join(paths.data, 'links'),


### PR DESCRIPTION
This sets the default values of "save" and "save-exact" config settings to false. This corresponds to PR bower/bower#2161 in the main bower repo from `feature/save-bowerrc-config` branch.

This doesn't change default operation of any bower commands. Just keeping this in sync with the main bower repo.