### PR TITLE
Loading only the needed mout functions

### DIFF
--- a/lib/Config.js
+++ b/lib/Config.js
@@ -1,5 +1,9 @@
-var lang = require('mout/lang');
-var object = require('mout/object');
+var lang = {
+    deepClone: require('mout/lang/deepClone')
+};
+var object = {
+    merge: require('mout/object/merge')
+};
 var rc = require('./util/rc');
 var expand = require('./util/expand');
 var EnvProxy = require('./util/proxy');

--- a/lib/util/expand.js
+++ b/lib/util/expand.js
@@ -1,6 +1,13 @@
-var object = require('mout/object');
-var lang = require('mout/lang');
-var string = require('mout/string');
+var object = {
+    forOwn: require('mout/object/forOwn')
+};
+var lang = {
+    isPlainObject: require('mout/lang/isPlainObject'),
+    isString: require('mout/lang/isString')
+};
+var string = {
+    camelCase: require('mout/string/camelCase')
+};
 
 function camelCase(config) {
     var camelCased = {};

--- a/lib/util/rc.js
+++ b/lib/util/rc.js
@@ -2,8 +2,16 @@ var path = require('path');
 var fs = require('graceful-fs');
 var optimist = require('optimist');
 var osenv = require('osenv');
-var object = require('mout/object');
-var string = require('mout/string');
+var object = {
+    map: require('mout/object/map'),
+    deepMixIn: require('mout/object/deepMixIn'),
+    merge: require('mout/object/merge'),
+    forOwn: require('mout/object/forOwn'),
+    set: require('mout/object/set')
+};
+var string = {
+    startsWith: require('mout/string/startsWith')
+};
 var paths = require('./paths');
 var defaults = require('./defaults');
 

--- a/test/test.js
+++ b/test/test.js
@@ -1,5 +1,6 @@
 var assert = require('assert');
 var path = require('path');
+var isWindows = (process.platform === 'win32');
 
 describe('NPM Config on package.json', function () {
     beforeEach(function () {
@@ -170,9 +171,11 @@ describe('NPM Config on package.json', function () {
             assert.equal(process.env.HTTPS_PROXY, 'http://HTTPS_PROXY');
             assert.equal(process.env.NO_PROXY, 'google.com');
 
-            assert.equal(process.env.http_proxy, undefined);
-            assert.equal(process.env.https_proxy, undefined);
-            assert.equal(process.env.no_proxy, undefined);
+            if (!isWindows) {
+                assert.equal(process.env.http_proxy, undefined);
+                assert.equal(process.env.https_proxy, undefined);
+                assert.equal(process.env.no_proxy, undefined);
+            }
         });
 
         it('restores env variables', function () {
@@ -186,9 +189,16 @@ describe('NPM Config on package.json', function () {
             var config = require('../lib/Config').create('test/assets/env-variables').load();
             config.restore();
 
-            assert.equal(process.env.HTTP_PROXY, 'a');
-            assert.equal(process.env.HTTPS_PROXY, 'b');
-            assert.equal(process.env.NO_PROXY, 'c');
+            if (isWindows) {
+                assert.equal(process.env.HTTP_PROXY, 'd');
+                assert.equal(process.env.HTTPS_PROXY, 'e');
+                assert.equal(process.env.NO_PROXY, 'f');
+            }
+            else {
+                assert.equal(process.env.HTTP_PROXY, 'a');
+                assert.equal(process.env.HTTPS_PROXY, 'b');
+                assert.equal(process.env.NO_PROXY, 'c');
+            }
 
             assert.equal(process.env.http_proxy, 'd');
             assert.equal(process.env.https_proxy, 'e');
@@ -227,7 +237,7 @@ describe('Allow ${ENV} variables in .bowerrc', function() {
 
         var config = require('../lib/Config').read('test/assets/env-variables-values');
         assert.equal('a', config.storage.packages);
-        assert.equal('/tmp/b', config.tmp);
+        assert.equal((isWindows ? 'C:\\tmp\\b' : '/tmp/b'), config.tmp);
         assert.equal('${_myshellvar}', config.scripts.postinstall);
     });
 });


### PR DESCRIPTION
A while back there was a pull request (#16) to only load the necessary parts of mout to improve the run time. By the time this was merged, the loading of individual functions seems to have been dropped in favor of loading all of mout/string, mout/object, and mout/lang.

This was a huge improvement, but it still takes, on my system, >600ms to require lib/Config.
```
658ms - lib\Config.js
275ms - lib\util\rc.js
229ms - node_modules\mout\lang.js
138ms - node_modules\mout\object.js
127ms - node_modules\mout\string.js
 74ms - node_modules\mout\lang\deepEquals.js
```
Loading only the needed functions improves the load time to ~315ms.
```
315ms - lib\Config.js
194ms - lib\util\rc.js
 72ms - lib\util\expand.js
 58ms - node_modules\mout\string\camelCase.js 
 54ms - node_modules\osenv\osenv.js
 43ms - child_process
```

While working on this, I found that several tests fail in windows.
Two because process.env is case insensitive in windows.
```
> process.env.A = 'foo';
'foo'
> process.env.a = 'bar';
'bar'
> process.env.A
'bar'
```
And one that path.resolves config.tmp.
Do you want me to put these into a different pull request?


