### PR TITLE
Remove unreachable code from parse function

### DIFF
--- a/lib/util/rc.js
+++ b/lib/util/rc.js
@@ -70,8 +70,6 @@ function parse(content, file) {
         error.code = 'EMALFORMED';
         throw error;
     }
-
-    return null;
 }
 
 function json(file) {


### PR DESCRIPTION
I found some unreachable code when looking through rc.js.